### PR TITLE
Increased the number of variables that can be exported from 20 to the maximum of 100

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,7 +14,7 @@ import (
 
 const APIHost = "https://gitlab.com"
 const APIEndpoint = "/api/v4/%s"
-const APIEndpointVars = "projects/%d/variables/%s"
+const APIEndpointVars = "projects/%d/variables/%s?per_page=100"
 const APIEndpointPersonalTokens = "personal_access_tokens/self"
 
 const timeout = time.Second * 3

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -179,7 +179,7 @@ func (v *VarsAPI) GetVariables(params types.Params) ([]types.Variable, error) {
 		return nil, err
 	}
 
-	endpoint := fmt.Sprintf(APIEndpointVars + "?per_page=100", params.ProjectId, params.Key)
+	endpoint := fmt.Sprintf(APIEndpointVars+"?per_page=100", params.ProjectId, params.Key)
 	resp, err := v.MakeRequestWithContext(ctx, "GET", endpoint, types.Filter{}, types.VarData{})
 	if err != nil {
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,7 +14,7 @@ import (
 
 const APIHost = "https://gitlab.com"
 const APIEndpoint = "/api/v4/%s"
-const APIEndpointVars = "projects/%d/variables/%s?per_page=100"
+const APIEndpointVars = "projects/%d/variables/%s"
 const APIEndpointPersonalTokens = "personal_access_tokens/self"
 
 const timeout = time.Second * 3
@@ -179,7 +179,7 @@ func (v *VarsAPI) GetVariables(params types.Params) ([]types.Variable, error) {
 		return nil, err
 	}
 
-	endpoint := fmt.Sprintf(APIEndpointVars, params.ProjectId, params.Key)
+	endpoint := fmt.Sprintf(APIEndpointVars + "?per_page=100", params.ProjectId, params.Key)
 	resp, err := v.MakeRequestWithContext(ctx, "GET", endpoint, types.Filter{}, types.VarData{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Increased the number of variables that can be exported from the default value of 20 to 100 which is the maximum possible using a single API call. This fixes #15 but still doesn't address the missing pagination and so will result in a new hard limit at 100. At least it makes it possible to export 5 times more variables than before which should be enough for the majority of projects.